### PR TITLE
956960: Added h1 tag in the Blazor Document Explorer

### DIFF
--- a/server/Components/App.razor
+++ b/server/Components/App.razor
@@ -31,6 +31,7 @@
 
 </head>
 <body>
+    <h1 role="heading" title="Document Explorer">Document Explorer</h1
     <Routes @rendermode="@InteractiveServer" />
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src=https://www.googletagmanager.com/ns.html?id=GTM-WLQL39J height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/server/Components/App.razor
+++ b/server/Components/App.razor
@@ -31,7 +31,6 @@
 
 </head>
 <body>
-    <h1 role="heading" title="Document Explorer">Document Explorer</h1
     <Routes @rendermode="@InteractiveServer" />
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src=https://www.googletagmanager.com/ns.html?id=GTM-WLQL39J height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/server/Pages/Index.razor
+++ b/server/Pages/Index.razor
@@ -32,7 +32,7 @@
                     </ToolbarItem>
                     <ToolbarItem Align="@ItemAlign.Left">
                         <Template>
-                            <div class="e-header-title">Document Explorer</div>
+                                <h1 class="e-header-title" title="Document Explorer">Document Explorer</h1>
                         </Template>
                     </ToolbarItem>
                     <ToolbarItem Align="@ItemAlign.Right" Id="User" OnClick="ToolbarClick" CssClass="@(_popupVisibility == "e-hide-popup" ? "e-user-icon" : "e-user-icon select-highlight")">


### PR DESCRIPTION
956960: Added h1 tag in the Blazor Document Explorer

**Output Image:**
<img width="966" alt="image" src="https://github.com/user-attachments/assets/24e37d47-4476-4e07-907f-d7050f41c338" />


